### PR TITLE
Adds ability to specify custom queues that a worker will work on 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ bundle exec rake db:migrate
 
 ## Configuration
 
-There is some configuration which is required. In a Rails application, you can place this in `config/initializers/cuetip.rb`.
+There is some configuration which is required. In a Rails application, in: `config/initializers/cuetip.rb`.
 
 ```ruby
 Cuetip.configure do |config|
@@ -35,6 +35,12 @@ Cuetip.configure do |config|
   end
 
 end
+```
+
+and in: `config/cuetip.rb`
+
+```
+require_relative 'environment'
 ```
 
 ## Jobs

--- a/bin/cuetip
+++ b/bin/cuetip
@@ -27,6 +27,13 @@ OptionParser.new do |opts|
   opts.on('-q NUMBER', 'The number of workers to run') do |i|
     options[:quantity] = i.to_i
   end
+
+  opts.on('-Q', '--queues QUEUE1,QUEUE2', 'Queues that you wish to work on') do |queues|
+    options[:queues] = []
+    queues.split(/,/).uniq.each do |queue|
+      options[:queues] << queue
+    end
+  end
 end.parse!
 
 if options[:config]
@@ -39,5 +46,5 @@ if options[:config]
   end
 end
 
-worker = Cuetip::WorkerGroup.new(options[:quantity].to_i == 0 ? Cuetip.config.worker_threads : options[:quantity].to_i)
+worker = Cuetip::WorkerGroup.new(options[:quantity].to_i == 0 ? Cuetip.config.worker_threads : options[:quantity].to_i, options[:queues])
 worker.start

--- a/bin/cuetip
+++ b/bin/cuetip
@@ -24,7 +24,7 @@ OptionParser.new do |opts|
     exit
   end
 
-  opts.on('-c NUMBER', 'The number of workers to run') do |i|
+  opts.on('-w NUMBER', 'The number of workers to run') do |i|
     options[:quantity] = i.to_i
   end
 

--- a/bin/cuetip
+++ b/bin/cuetip
@@ -24,11 +24,11 @@ OptionParser.new do |opts|
     exit
   end
 
-  opts.on('-q NUMBER', 'The number of workers to run') do |i|
+  opts.on('-c NUMBER', 'The number of workers to run') do |i|
     options[:quantity] = i.to_i
   end
 
-  opts.on('-Q', '--queues QUEUE1,QUEUE2', 'Queues that you wish to work on') do |queues|
+  opts.on('-q', '--queues QUEUE1,QUEUE2', 'Queues that you wish to work on') do |queues|
     options[:queues] = []
     queues.split(/,/).uniq.each do |queue|
       options[:queues] << queue

--- a/lib/cuetip/models/job.rb
+++ b/lib/cuetip/models/job.rb
@@ -67,6 +67,8 @@ module Cuetip
         # Initialize a new instance of the job we wish to execute
         job_klass = class_name.constantize.new(self)
 
+        Cuetip.config.emit(:started, self, job_klass)
+
         # If the job has expired, we should not be executing this so we'll just
         # remove it from the queue and mark it as expired.
         if expired?

--- a/lib/cuetip/models/job.rb
+++ b/lib/cuetip/models/job.rb
@@ -67,8 +67,6 @@ module Cuetip
         # Initialize a new instance of the job we wish to execute
         job_klass = class_name.constantize.new(self)
 
-        Cuetip.config.emit(:before_perform, self, job_klass)
-
         # If the job has expired, we should not be executing this so we'll just
         # remove it from the queue and mark it as expired.
         if expired?
@@ -78,6 +76,8 @@ module Cuetip
           Cuetip.config.emit(:expired, self, job_klass)
           return false
         end
+
+        Cuetip.config.emit(:before_perform, self, job_klass)
 
         # If we have a block, call this so we can manipulate our actual job class
         # before execution if needed (mostly for testing)

--- a/lib/cuetip/models/job.rb
+++ b/lib/cuetip/models/job.rb
@@ -67,7 +67,7 @@ module Cuetip
         # Initialize a new instance of the job we wish to execute
         job_klass = class_name.constantize.new(self)
 
-        Cuetip.config.emit(:started, self, job_klass)
+        Cuetip.config.emit(:before_perform, self, job_klass)
 
         # If the job has expired, we should not be executing this so we'll just
         # remove it from the queue and mark it as expired.

--- a/lib/cuetip/models/queued_job.rb
+++ b/lib/cuetip/models/queued_job.rb
@@ -30,14 +30,10 @@ module Cuetip
       end
 
       # Simultaneously find an outstanding job and lock it
-      def self.find_and_lock(queued_job_id = nil, queue_name = nil)
+      def self.find_and_lock(queued_job_id = nil)
         lock_id = generate_lock_id
         scope = if queued_job_id
-                  if queue_name
-                    where(id: queued_job_id, queue_name: queue_name)
-                  else
-                    where(id: queued_job_id)
-                  end
+                  where(id: queued_job_id)
                 else
                   self
                 end

--- a/lib/cuetip/version.rb
+++ b/lib/cuetip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Cuetip
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/lib/cuetip/worker.rb
+++ b/lib/cuetip/worker.rb
@@ -37,10 +37,11 @@ module Cuetip
       run_callbacks :poll do
         queued_job = silence do
           if @queues.any?
-            Cuetip::Models::QueuedJob.from_queues(@queues).find_and_lock
+            scope = Cuetip::Models::QueuedJob.from_queues(@queues)
           else
-            Cuetip::Models::QueuedJob.find_and_lock
+            scope = Cuetip::Models::QueuedJob
           end
+          scope.find_and_lock
         end
 
         if queued_job

--- a/lib/cuetip/worker_group.rb
+++ b/lib/cuetip/worker_group.rb
@@ -12,8 +12,9 @@ module Cuetip
     attr_reader :workers
     attr_reader :threads
 
-    def initialize(quantity)
+    def initialize(quantity, queues)
       @quantity = quantity
+      @queues = queues || []
       @workers = {}
       @threads = {}
     end
@@ -30,7 +31,7 @@ module Cuetip
       trap('TERM', &exit_trap)
 
       @quantity.times do |i|
-        @workers[i] = Worker.new(self, i)
+        @workers[i] = Worker.new(self, i, @queues)
         Cuetip.logger.info "-> Starting worker #{i}"
         @threads[i] = Thread.new(@workers[i]) do |worker|
           run_callbacks :run_worker do

--- a/lib/cuetip/worker_group.rb
+++ b/lib/cuetip/worker_group.rb
@@ -21,6 +21,9 @@ module Cuetip
 
     def start
       Cuetip.logger.info "Starting #{@quantity} Cuetip workers"
+      if @queues.any?
+        @queues.each { |q| Cuetip.logger.info "-> Joined queue: #{q.to_s}" }
+      end
 
       exit_trap = proc do
         @workers.each { |_, worker| worker.request_exit! }

--- a/spec/specs/worker_spec.rb
+++ b/spec/specs/worker_spec.rb
@@ -6,13 +6,28 @@ require 'cuetip/worker_group'
 
 describe Cuetip::Worker do
   context 'running' do
-    subject(:worker_group) { Cuetip::WorkerGroup.new(1) }
-    subject(:worker)     { Cuetip::Worker.new(worker_group, 0) }
+    subject(:worker_group) { Cuetip::WorkerGroup.new(1, []) }
+    subject(:worker)     { Cuetip::Worker.new(worker_group, 0, []) }
     subject(:job)        { Cuetip::Models::Job.create! }
     subject(:queued_job) { Cuetip::Models::QueuedJob.create!(job: job) }
 
     it 'should execute a job' do
       allow(Cuetip::Models::QueuedJob).to receive(:find_and_lock).and_return(queued_job)
+      allow(job).to receive(:execute)
+      worker.run_once
+      expect(job).to have_received(:execute)
+    end
+  end
+
+  context 'running with queues' do
+    subject(:queues)        { ['primary'] }
+    subject(:worker_group)  { Cuetip::WorkerGroup.new(1, queues) }
+    subject(:worker)        { Cuetip::Worker.new(worker_group, 0, queues) }
+    subject(:job)           { Cuetip::Models::Job.create!(queue_name: queues.first) }
+    subject(:queued_job)    { Cuetip::Models::QueuedJob.create!(job: job) }
+
+    it 'should execute a job in it\'s own queue' do
+      Cuetip::Models::QueuedJob.stub_chain(:from_queues, :find_and_lock).with(queues).with(no_args).and_return(queued_job)
       allow(job).to receive(:execute)
       worker.run_once
       expect(job).to have_received(:execute)


### PR DESCRIPTION
This PR extends the current cuetip configuration by adding a new (`-Q`) option to the worker. Multiple comma separated values can be passed to this option. i.e:
`worker_main: bundle exec cuetip -c config/cuetip.rb -Q foreground,background`
Then the worker above will only pick up queued jobs from these specific queues

Another small change has been introduced in `Cuetip::Models::Job#execute`, the function can now run `:started` callbacks defined in the config file.