### PR TITLE
Ability to prune old jobs from the table

### DIFF
--- a/lib/cuetip/job.rb
+++ b/lib/cuetip/job.rb
@@ -62,6 +62,13 @@ module Cuetip
         # Return the job
         job
       end
+
+      # Prune jobs before a specific time
+      #
+      # @param before [ActiveSupport::TimeWithZone] The point in time to prune jobs until.
+      def prune(before)
+        Models::Job.where('created_at < ?', before).destroy_all
+      end
     end
 
     # Initialize this job instance by providing a queued job instance
@@ -75,13 +82,6 @@ module Cuetip
     #
     # @return [void]
     def perform; end
-
-    # Prune jobs before a specific time
-    #
-    # @param before [ActiveSupport::TimeWithZone] The point in time to prune jobs until.
-    def self.prune(before)
-      Models::Job.where('created_at < ?', before).destroy_all
-    end
 
     private
 

--- a/lib/cuetip/job.rb
+++ b/lib/cuetip/job.rb
@@ -76,6 +76,13 @@ module Cuetip
     # @return [void]
     def perform; end
 
+    # Prune jobs before a specific time
+    #
+    # @param before [ActiveSupport::TimeWithZone] The point in time to prune jobs until.
+    def self.prune(before)
+      Models::Job.where('created_at < ?', before).destroy_all
+    end
+
     private
 
     # Return all parameters for the job

--- a/spec/specs/job_spec.rb
+++ b/spec/specs/job_spec.rb
@@ -23,4 +23,18 @@ describe Cuetip::Job do
       expect(job.queue_name).to eq 'anotherqueue'
     end
   end
+
+  context '#prune' do
+    it 'should prune jobs created before the specified date' do
+      job = Cuetip::Job.queue
+
+      job.update(created_at: 2.months.ago)
+
+      expect(Cuetip::Models::Job.find_by(id: job.id)).to eq job
+
+      Cuetip::Job.prune(1.month.ago)
+
+      expect(Cuetip::Models::Job.find_by(id: job.id)).to eq nil
+    end
+  end
 end


### PR DESCRIPTION
I've added a new class method to `Cuetip::Job` to prune jobs that are older than a given date. It's simple to call, to prune jobs from a month ago you'd run `Cuetip::Job.prune(1.month.ago)`.